### PR TITLE
GHC-7.8-rc2 imagines you need -XImpredicativeTypes

### DIFF
--- a/src/Data/Functor/Kan/Lift.hs
+++ b/src/Data/Functor/Kan/Lift.hs
@@ -47,7 +47,7 @@ import Data.Functor.Rep
 newtype Lift g f a = Lift { runLift :: forall z. Functor z => (forall x. f x -> g (z x)) -> z a }
 
 instance Functor (Lift g h) where
-  fmap f (Lift g) = Lift (fmap f . g)
+  fmap f (Lift g) = Lift (\x -> fmap f (g x))
   {-# INLINE fmap #-}
 
 instance (Functor g, g ~ h) => Copointed (Lift g h) where
@@ -63,7 +63,7 @@ glift = leftAdjunct (\lka -> Lift (\k2gz -> rightAdjunct k2gz lka))
 
 -- | The universal property of 'Lift'
 toLift :: Functor z => (forall a. f a -> g (z a)) -> Lift g f b -> z b
-toLift = flip runLift
+toLift f l =  runLift l f
 {-# INLINE toLift #-}
 
 -- | When the adjunction exists


### PR DESCRIPTION
I was installing this to get the Codensity module, and bumped into this nonsense. Curiously if I just do `cabal configure` and `cabal build` it doesn't complain. The compiler falls for this patch, but that's as much as I can claim for it. 

Configuring kan-extensions-4.0.1...
Building kan-extensions-4.0.1...
Preprocessing library kan-extensions-4.0.1...
[ 1 of 11] Compiling Data.Functor.Kan.Rift ( src/Data/Functor/Kan/Rift.hs, dist/build/Data/Functor/Kan/Rift.o )
[ 2 of 11] Compiling Data.Functor.Kan.Lift ( src/Data/Functor/Kan/Lift.hs, dist/build/Data/Functor/Kan/Lift.o )

src/Data/Functor/Kan/Lift.hs:50:27:
    Cannot instantiate unification variable ‘a0’
    with a type involving foralls: forall x. h x -> g (z x)
      Perhaps you want ImpredicativeTypes
    In the first argument of ‘Lift’, namely ‘(fmap f . g)’
    In the expression: Lift (fmap f . g)
    In an equation for ‘fmap’: fmap f (Lift g) = Lift (fmap f . g)

src/Data/Functor/Kan/Lift.hs:50:36:
    Cannot instantiate unification variable ‘a0’
    with a type involving foralls: forall x. h x -> g (z x)
      Perhaps you want ImpredicativeTypes
    In the second argument of ‘(.)’, namely ‘g’
    In the first argument of ‘Lift’, namely ‘(fmap f . g)’

src/Data/Functor/Kan/Lift.hs:66:10:
    Cannot instantiate unification variable ‘b0’
    with a type involving foralls: forall a. f a -> g (z a)
      Perhaps you want ImpredicativeTypes
    In the expression: flip runLift
    In an equation for ‘toLift’: toLift = flip runLift

src/Data/Functor/Kan/Lift.hs:66:15:
    Cannot instantiate unification variable ‘b0’
    with a type involving foralls: forall x. f x -> g (z x)
      Perhaps you want ImpredicativeTypes
    In the first argument of ‘flip’, namely ‘runLift’
    In the expression: flip runLift
