### PR TITLE
Modernize some things

### DIFF
--- a/src/Control/Monad/Codensity.hs
+++ b/src/Control/Monad/Codensity.hs
@@ -45,7 +45,6 @@ import Data.Functor.Plus
 import Data.Functor.Rep
 #if __GLASGOW_HASKELL__ >= 708
 import Data.Typeable
-import Data.Coerce
 #endif
 
 -- |
@@ -91,18 +90,8 @@ instance MonadIO m => MonadIO (Codensity m) where
   {-# INLINE liftIO #-}
 
 instance MonadTrans Codensity where
-#if __GLASGOW_HASKELL__ >= 708
-  lift = Codensity #. (>>=)
-#else
   lift m = Codensity (m >>=)
-#endif
   {-# INLINE lift #-}
-
-#if __GLASGOW_HASKELL__ >= 708
-( #. ) :: Coercible c b => (b -> c) -> (a -> b) -> a -> c
-( #. ) _ = coerce (\x -> x :: b) :: forall a b. Coercible b a => a -> b
-{-# INLINE ( #. ) #-}
-#endif
 
 instance Alt v => Alt (Codensity v) where
   Codensity m <!> Codensity n = Codensity (\k -> m k <!> n k)

--- a/src/Control/Monad/Codensity.hs
+++ b/src/Control/Monad/Codensity.hs
@@ -8,7 +8,6 @@
 #endif
 #if __GLASGOW_HASKELL__ >= 708
 {-# LANGUAGE DeriveDataTypeable #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 #endif
 
 -----------------------------------------------------------------------------
@@ -32,7 +31,7 @@ module Control.Monad.Codensity
   ) where
 
 import Control.Applicative
-import Control.Monad (ap, MonadPlus(..))
+import Control.Monad (MonadPlus(..))
 import Control.Monad.Free
 import Control.Monad.IO.Class
 import Control.Monad.Reader.Class

--- a/src/Control/Monad/Codensity.hs
+++ b/src/Control/Monad/Codensity.hs
@@ -3,11 +3,12 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 702
+#if __GLASGOW_HASKELL__ >= 702
 {-# LANGUAGE Trustworthy #-}
 #endif
-#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 708
+#if __GLASGOW_HASKELL__ >= 708
 {-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 #endif
 
 -----------------------------------------------------------------------------
@@ -42,8 +43,9 @@ import Data.Functor.Apply
 import Data.Functor.Kan.Ran
 import Data.Functor.Plus
 import Data.Functor.Rep
-#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 708
+#if __GLASGOW_HASKELL__ >= 708
 import Data.Typeable
+import Data.Coerce
 #endif
 
 -- |
@@ -60,7 +62,7 @@ import Data.Typeable
 newtype Codensity m a = Codensity
   { runCodensity :: forall b. (a -> m b) -> m b
   }
-#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 708
+#if __GLASGOW_HASKELL__ >= 708
     deriving Typeable
 #endif
 
@@ -69,13 +71,13 @@ instance Functor (Codensity k) where
   {-# INLINE fmap #-}
 
 instance Apply (Codensity f) where
-  (<.>) = ap
+  (<.>) = (<*>)
   {-# INLINE (<.>) #-}
 
 instance Applicative (Codensity f) where
   pure x = Codensity (\k -> k x)
   {-# INLINE pure #-}
-  (<*>) = ap
+  Codensity f <*> Codensity g = Codensity (\bfr -> f (\ab -> g (bfr . ab)))
   {-# INLINE (<*>) #-}
 
 instance Monad (Codensity f) where
@@ -89,8 +91,18 @@ instance MonadIO m => MonadIO (Codensity m) where
   {-# INLINE liftIO #-}
 
 instance MonadTrans Codensity where
+#if __GLASGOW_HASKELL__ >= 708
+  lift = Codensity #. (>>=)
+#else
   lift m = Codensity (m >>=)
+#endif
   {-# INLINE lift #-}
+
+#if __GLASGOW_HASKELL__ >= 708
+( #. ) :: Coercible c b => (b -> c) -> (a -> b) -> a -> c
+( #. ) _ = coerce (\x -> x :: b) :: forall a b. Coercible b a => a -> b
+{-# INLINE ( #. ) #-}
+#endif
 
 instance Alt v => Alt (Codensity v) where
   Codensity m <!> Codensity n = Codensity (\k -> m k <!> n k)
@@ -116,11 +128,19 @@ instance Alternative v => Alternative (Codensity v) where
   Codensity m <|> Codensity n = Codensity (\k -> m k <|> n k)
   {-# INLINE (<|>) #-}
 
+#if __GLASGOW_HASKELL__ >= 710
+instance Alternative v => MonadPlus (Codensity v) where
+  mzero = empty
+  {-# INLINE mzero #-}
+  mplus = (<|>)
+  {-# INLINE mplus #-}
+#else
 instance MonadPlus v => MonadPlus (Codensity v) where
   mzero = Codensity (\_ -> mzero)
   {-# INLINE mzero #-}
   Codensity m `mplus` Codensity n = Codensity (\k -> m k `mplus` n k)
   {-# INLINE mplus #-}
+#endif
 
 -- |
 -- This serves as the *left*-inverse (retraction) of 'lift'.
@@ -136,8 +156,13 @@ instance MonadPlus v => MonadPlus (Codensity v) where
 -- e.g. @'Codensity' ((->) s)) a ~ forall r. (a -> s -> r) -> s -> r@
 -- could support a full complement of @'MonadState' s@ actions, while @(->) s@
 -- is limited to @'MonadReader' s@ actions.
+#if __GLASGOW_HASKELL__ >= 710
+lowerCodensity :: Applicative f => Codensity f a -> f a
+lowerCodensity a = runCodensity a pure
+#else
 lowerCodensity :: Monad m => Codensity m a -> m a
 lowerCodensity a = runCodensity a return
+#endif
 {-# INLINE lowerCodensity #-}
 
 -- | The 'Codensity' monad of a right adjoint is isomorphic to the


### PR DESCRIPTION
1. Weaken constraint of `lowerCodensity` from `Monad f =>` to `Applicative f`.
2. Weaken constraint on `MonadPlus` instance from `MonadPlus v` to `Alternative v`.
3. Inline `>>=` in the definition of `<*>` and reduce by hand.