### PR TITLE
Use default `MonadPlus` instance

### DIFF
--- a/src/Control/Monad/Codensity.hs
+++ b/src/Control/Monad/Codensity.hs
@@ -117,11 +117,7 @@ instance Alternative v => Alternative (Codensity v) where
   {-# INLINE (<|>) #-}
 
 #if __GLASGOW_HASKELL__ >= 710
-instance Alternative v => MonadPlus (Codensity v) where
-  mzero = empty
-  {-# INLINE mzero #-}
-  mplus = (<|>)
-  {-# INLINE mplus #-}
+instance Alternative v => MonadPlus (Codensity v)
 #else
 instance MonadPlus v => MonadPlus (Codensity v) where
   mzero = Codensity (\_ -> mzero)


### PR DESCRIPTION
I forgot we don't actually need to define anything for `MonadPlus` any more.