### PR TITLE
Only require `Functor` for `Eq`/`Ord` `Coyoneda` instances when using `transformers-0.4.*`

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,8 @@
+next [????.??.??]
+-----------------
+* Only require a `Functor` constraint in the `Eq` and `Ord` instances for
+  `Coyoneda` when building against `transformers-0.4.*`.
+
 5.2.4 [2022.05.07]
 ------------------
 * Allow building with `transformers-0.6.*` and `mtl-2.3.*`.

--- a/src/Data/Functor/Coyoneda.hs
+++ b/src/Data/Functor/Coyoneda.hs
@@ -287,11 +287,19 @@ instance (Functor f, Ord1 f) => Ord1 (Coyoneda f) where
   {-# INLINE compare1 #-}
 #endif
 
-instance (Functor f, Eq1 f, Eq a) => Eq (Coyoneda f a) where
+instance ( Eq1 f, Eq a
+#if !LIFTED_FUNCTOR_CLASSES
+         , Functor f
+#endif
+         ) => Eq (Coyoneda f a) where
   (==) = eq1
   {-# INLINE (==) #-}
 
-instance (Functor f, Ord1 f, Ord a) => Ord (Coyoneda f a) where
+instance ( Ord1 f, Ord a
+#if !LIFTED_FUNCTOR_CLASSES
+         , Functor f
+#endif
+         ) => Ord (Coyoneda f a) where
   compare = compare1
   {-# INLINE compare #-}
 


### PR DESCRIPTION
When building with all other versions of `transformers`, the `Functor` instance is entirely redundant.

This should also allow `kan-extensions` to compile with the changes in haskell/core-libraries-committee#10. cc @Bodigrim