### PR TITLE
Yoneda: More stack-efficient (.>) and (*>)

### DIFF
--- a/src/Data/Functor/Yoneda.hs
+++ b/src/Data/Functor/Yoneda.hs
@@ -113,12 +113,16 @@ instance Functor (Yoneda f) where
 instance Apply f => Apply (Yoneda f) where
   Yoneda m <.> Yoneda n = Yoneda (\f -> m (f .) <.> n id)
   {-# INLINE (<.>) #-}
+  Yoneda m .> Yoneda n = Yoneda (\f -> m id .> n f)
+  {-# INLINE (.>) #-}
 
 instance Applicative f => Applicative (Yoneda f) where
   pure a = Yoneda (\f -> pure (f a))
   {-# INLINE pure #-}
   Yoneda m <*> Yoneda n = Yoneda (\f -> m (f .) <*> n id)
   {-# INLINE (<*>) #-}
+  Yoneda m *> Yoneda n = Yoneda (\f -> m id *> n f)
+  {-# INLINE (*>) #-}
 
 instance Foldable f => Foldable (Yoneda f) where
   foldMap f = foldMap f . lowerYoneda


### PR DESCRIPTION
To see the difference, run this file before and after patch with `GHCRTS=-K100k cabal exec runghc`:

```hs
import Data.Functor.Yoneda

times :: Applicative f => Integer -> f a -> f a
times 1 m = m
times n m = m *> times (n - 1) m

main :: IO ()
main = lowerYoneda $ times 10000 $ pure ()
```